### PR TITLE
Allow plain Arrays and Vectors to be used as arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,14 @@ General Considerations
 
 - All arguments are passed as named hash values matching the openscad spec, exceptions are for functions fa, fs, fn, echo, include, and use (see below).  
   openscad: `cube(6)`  
-  rubyscad: `cube(size: 6)`
+  rubyscad: `cube(size: 6)`  
+- It is however possible to use ruby arrays (or vectors and even matrices) as an argument instead of a hash as a shortcut.  
+  The following 4 snippets produce identical output.  
+  openscad:  `cube(size = [6,6,12]);`  
+  rubyscad:  `cube(size: [6,6,12])`  
+  openscad:  `cube([6,6,12]);`  
+  rubyscad:  `cube([6,6,12])`  
+  Please notice though that Rubyscad doesn't check if the code with an array as argument is valid openscad code, eg. `cylinder([10,10,5])` becomes `cylinder([10, 10, 5]);`, which is nonsense openscad code.  
 - Any hash values may be passed to functions (with the exception of the ones noted above) but openscad may or may not use these values  
   *cube(openscadwontusethis: 5)* will produce *cube(openscadwontusethis = 5);*
   nothing bad will happen here, the value will just have no effect

--- a/lib/rubyscad/RubyScad.rb
+++ b/lib/rubyscad/RubyScad.rb
@@ -229,11 +229,14 @@ module RubyScad
   end
 
   def format_command(cmd_str, args={}, &block)
-    unless args.kind_of? String
-        arg_str = args.collect { |k, v| "#{format_key(k)} = #{format_value(v)}" }.join(', ')
+    if args.kind_of? String
+      arg_str = args
+    elsif [Array, Vector, Matrix].any? { |klass| args.is_a? klass }
+      arg_str = format_value(args)
     else
-        arg_str = args
+      arg_str = args.collect { |k, v| "#{format_key(k)} = #{format_value(v)}" }.join(', ')
     end
+
     format_block cmd_str % {args: arg_str}, &block
   end
   
@@ -258,6 +261,7 @@ module RubyScad
   end
 
   def vector_input(args, element)
+    return unless args.is_a? Hash
     unless args.include?(element)
       args[element] = [args.fetch(:x, 0), args.fetch(:y, 0)]
       args[element].push(args[:z]) if args.include?(:z)


### PR DESCRIPTION
openscad allows code without parameter names like this `translate([-10,0,0]) cube([10,20,10]);`, because typing them all the time is annoying.

This commit makes the same thing possible in RubyScad, so that `translate([-10,0,0])` and `cube([10,20,10])` just work as expected. It's also possible to use Vectors and even Matrices as arguments.

Furthermore also the Readme was updated to document the new behavior.

I hope I implemented the change not too hacky, feel free to tell me how to do it better. I'd be happy to update this pull requests if there are any problems/nits.
